### PR TITLE
fix(autocrop): correct swapped trim_up and trim_left in _init_auto_crop

### DIFF
--- a/src/mvcrender/autocrop/_native.c
+++ b/src/mvcrender/autocrop/_native.c
@@ -465,7 +465,7 @@ static PyObject* AutoCrop__init_auto_crop(AutoCropObject* self, PyObject* Py_UNU
         }
         if (self->trim_left || self->trim_up || self->trim_right || self->trim_down){
             Py_XDECREF(self->auto_crop);
-            self->auto_crop = make_list4(self->trim_up, self->trim_left, self->trim_right, self->trim_down);
+            self->auto_crop = make_list4(self->trim_left, self->trim_up, self->trim_right, self->trim_down);
             (void)AutoCrop_auto_crop_offset(self, NULL);
             // Update shared ref dimensions when using predefined trims
             (void)AutoCrop__calculate_trimmed_dimensions(self, NULL);


### PR DESCRIPTION
## Bug

In `_init_auto_crop()`, the `auto_crop` list was initialized with swapped parameters:

```c
// BUGGY (line 468):
self->auto_crop = make_list4(self->trim_up, self->trim_left, self->trim_right, self->trim_down);
//                            ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^ — swapped!
```

This produces `auto_crop = [trim_up, trim_left, trim_right, trim_down]`.

However, **all consumers** of `auto_crop` read it as `[left, up, right, down]`:

- `auto_crop_offset()`: `l = auto_crop[0]`, `u = auto_crop[1]`
- `async_check_if_zoom_is_on()`: `l = auto_crop[0]`, `u = auto_crop[1]`
- `auto_trim_and_zoom_image()` (line 844): `make_list4(self->trim_left, self->trim_up, ...)` — correct order
- `_async_auto_crop_data()` (line 435): `make_list4(l, u, r, d)` where `l=trim_left` — correct order

The only call site using the wrong order is `_init_auto_crop()` at line 468.

## Impact

When `trim_left > trim_up`, the crop region's Y origin (`y0`) becomes `trim_left` instead of `trim_up`, shifting the crop window down and cutting off rooms in the upper portion of the vacuum map. For example, with `trim_left=2242` and `trim_up=1407`, all rooms with image rows below 2242 become invisible.

## Fix

Swap the first two arguments to match the `[left, up, right, down]` order used everywhere else:

```c
// FIXED:
self->auto_crop = make_list4(self->trim_left, self->trim_up, self->trim_right, self->trim_down);
```

## Testing

Verified on a live Home Assistant instance with a Roborock S7 (Valetudo) — all 8 rooms now render correctly. Image dimensions changed from 942x2137 (incorrect crop) to 1777x1302 (correct crop).
